### PR TITLE
Remove net461 from build

### DIFF
--- a/src/KubernetesClient/KubernetesClient.csproj
+++ b/src/KubernetesClient/KubernetesClient.csproj
@@ -10,8 +10,8 @@
     <PackageIconUrl>https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png</PackageIconUrl>
     <PackageTags>kubernetes;docker;containers;</PackageTags>
 
-    <TargetFrameworks>netstandard1.4;netstandard2.0;net452;net461;netcoreapp2.1;xamarinios10;monoandroid81</TargetFrameworks>
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Core'">netstandard1.4;netstandard2.0;net452;net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;netstandard2.0;net452;netcoreapp2.1;xamarinios10;monoandroid81</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Core'">netstandard1.4;netstandard2.0;net452;netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.4;netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>k8s</RootNamespace>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
The test project is net core so we need to build the net standard version - this is fine though as `net452` will be the only full framework version published, and that's what is resolved by nuget